### PR TITLE
Fix SQLAlchemy env var in OpenShift workflow

### DIFF
--- a/.github/workflows/openshift.yml
+++ b/.github/workflows/openshift.yml
@@ -37,7 +37,7 @@ env:
 
   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
-  SQALCHEMY_DATABASE_URI: ${{ secrets.SQLALCHEMY_DATABASE_URI }}
+  SQLALCHEMY_DATABASE_URI: ${{ secrets.SQLALCHEMY_DATABASE_URI }}
 
   # 🖊️ EDIT to set a name for your OpenShift app, or a default one will be generated below.
   APP_NAME: ai-cto


### PR DESCRIPTION
## Summary
- fix the `SQLALCHEMY_DATABASE_URI` environment variable name in the OpenShift workflow

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685bef4e4a2c83299544b071cdeeffee