### PR TITLE
Fix BmcValidator static methods and update calls

### DIFF
--- a/src/controllers/project_controller.py
+++ b/src/controllers/project_controller.py
@@ -158,8 +158,8 @@ def process_project(data):
         asistant_response = response_json.pop('assistant_response', None)
         print("tämä on assistant response \n",response_json)
 
-        ans = BMC.current_vs_ideal_score(BMC,response_json)
-        score = BMC.calculate_score(BMC, ans)
+        ans = BMC.current_vs_ideal_score(response_json)
+        score = BMC.calculate_score(ans) if ans is not None else None
         return (
             jsonify(
                 {

--- a/src/services/BMC_recources.py
+++ b/src/services/BMC_recources.py
@@ -127,7 +127,8 @@ class BmcValidator(BaseModel):
     numerical_data_realism: bool
     clarity_and_readability: bool
 
-    def calculate_score(self, validation: 'BmcValidator') -> int:
+    @staticmethod
+    def calculate_score(validation: 'BmcValidator') -> int:
         """
         Laskee numeerisen pisteytyksen sen perusteella, kuinka moni arvo on False.
 
@@ -143,7 +144,8 @@ class BmcValidator(BaseModel):
                 score -= round(16.67, 1)
         return score
 
-    def load_ideal_bmc(self):
+    @staticmethod
+    def load_ideal_bmc():
         """
         Loads the ideal Business Model Canvas (BMC) from a JSON file.
         this can be used to compare the current BMC with the ideal BMC and other stuff
@@ -155,7 +157,8 @@ class BmcValidator(BaseModel):
             ideal_bmc_list = json.load(f)
         return ideal_bmc_list
 
-    def current_vs_ideal_score(self, bmc:json) -> None:
+    @staticmethod
+    def current_vs_ideal_score(bmc: json) -> 'BmcValidator | None':
         """
         Päivittää nykyisen BMC-olion uusilla tiedoilla ilman, että aiemmat tiedot ylikirjoitetaan.
 


### PR DESCRIPTION
## Summary
- mark `calculate_score`, `load_ideal_bmc`, and `current_vs_ideal_score` as static methods
- update `project_controller` to call BmcValidator methods correctly
- guard against None when calculating the score

## Testing
- `bash run_tests.sh` *(fails: OPENAI_API_KEY not set)*

------
https://chatgpt.com/codex/tasks/task_e_685bface0c588329ad8c9437f21493b5