### PR TITLE
Store BMC data with projects

### DIFF
--- a/src/controllers/project_controller.py
+++ b/src/controllers/project_controller.py
@@ -65,8 +65,7 @@ def process_project(data):
             project = Project.query.get(project_id)
             if project:
                 thread_id = project.thread_id
-                # Update the project_type if provided
-                project.project_type = project_type
+                project.type = project_type  # ensure stored correctly
                 db.session.commit()
             else:
                 return jsonify({"error": "Project not found"}), 404
@@ -183,6 +182,11 @@ def process_project(data):
         store[str(thread_id)] = response_json
         save_bmc_store(store)
 
+        # Persist BMC data on the project
+        if project:
+            project.bmc_data = json.dumps(response_json)
+            db.session.commit()
+
         ans = BMC.current_vs_ideal_score(response_json)
         score = BMC.calculate_score(ans) if ans is not None else None
         return (
@@ -227,10 +231,14 @@ def evaluate_project(data):
         if not thread_id:
             return jsonify({"error": "Missing thread_id"}), 400
 
-        store = load_bmc_store()
-        bmc_data = store.get(str(thread_id))
-        if not bmc_data:
+        project = Project.query.filter_by(thread_id=thread_id).first()
+        if not project:
+            return jsonify({"error": "Project not found"}), 404
+
+        if not project.bmc_data:
             return jsonify({"error": "No BMC data found for thread"}), 404
+
+        bmc_data = json.loads(project.bmc_data)
 
         from services.bmc_fca_score import fcp_score, MCDM
 
@@ -244,17 +252,12 @@ def evaluate_project(data):
         impact = ranking.get("impact_rank", 0)
         name = bmc_data.get("company_name", "Pending Evaluation")
 
-        project = Project.query.filter_by(thread_id=thread_id).first()
-
-        if not project:
-            return jsonify({"error": "Project not found"}), 404
-
         # Update project details
         project.x_value = x_value
         project.y_value = y_value
         project.impact = impact
         project.name = name
-        project.project_type = project_type  # Update project_type
+        project.type = project_type
         db.session.commit()
 
         result = {

--- a/src/models/models.py
+++ b/src/models/models.py
@@ -6,6 +6,7 @@ Database models to represent application users and projects
 #pylint: disable=too-few-public-methods
 
 from datetime import datetime, timezone
+import json
 
 from flask_sqlalchemy import SQLAlchemy
 db = SQLAlchemy()
@@ -71,6 +72,7 @@ class Project(db.Model):
         onupdate=lambda: datetime.now(timezone.utc),
     )
     type = db.Column(db.String, nullable=False, default="Idea")  # New field
+    bmc_data = db.Column(db.Text, nullable=True)
 
     def to_dict(self):
         """
@@ -89,4 +91,5 @@ class Project(db.Model):
             "thread_id": self.thread_id,
             "timestamp": self.timestamp.isoformat() if self.timestamp else None,
             "project_type": self.type,
+            "bmc_data": json.loads(self.bmc_data) if self.bmc_data else None,
         }


### PR DESCRIPTION
## Summary
- extend `Project` model with `bmc_data` column
- persist extracted BMC JSON during `process_project`
- load stored BMC data during project evaluation

## Testing
- `./run_tests.sh` *(fails: OPENAI_API_KEY not set)*

------
https://chatgpt.com/codex/tasks/task_e_685c580669888329b85b94ddf15da2b7