### PR TITLE
Add FCA score evaluation

### DIFF
--- a/src/controllers/project_controller.py
+++ b/src/controllers/project_controller.py
@@ -7,6 +7,7 @@ from models.models import Project, db
 from services.api_assist import IdeaGenerator
 from services.bokeh_visualization import create_scatter_plot
 from services.openai_service import extract_text_from_pdf
+from services.BMC_recources import BusinessModelCanvas, BmcValidator
 
 
 
@@ -165,36 +166,34 @@ def process_project(data):
 def evaluate_project(data):
     try:
         client = OpenAI()
-        generator = IdeaGenerator(client)
         thread_id = data.get("thread_id")
 
         if not thread_id:
             return jsonify({"error": "Missing thread_id"}), 400
 
-        generator.thread_id = thread_id
-        evaluation_result = generator.evaluate()
+        # Fetch conversation history for the thread
+        messages = client.beta.threads.messages.list(thread_id=thread_id)
+        conversation = ""
+        for msg in messages.data:
+            for block in msg.content:
+                if hasattr(block, "text") and hasattr(block.text, "value"):
+                    conversation += block.text.value + "\n"
 
-        if not evaluation_result:
-            return jsonify({"error": "Evaluation failed"}), 500
-
-        x_value = evaluation_result.get("x_value", 0)
-        y_value = evaluation_result.get("y_value", 0)
-        impact = evaluation_result.get("impact", 0)
-        name = evaluation_result.get("name", "Pending Evaluation")
+        # Build and evaluate the business model canvas
+        bmc = BusinessModelCanvas()
+        bmc.update_from_text(conversation)
+        validation = BmcValidator.current_vs_ideal_score(bmc.model_dump())
+        fca_score = BmcValidator.calculate_score(validation)
 
         project = Project.query.filter_by(thread_id=thread_id).first()
 
         if not project:
             return jsonify({"error": "Project not found"}), 404
 
-        project.x_value = x_value
-        project.y_value = y_value
-        project.impact = impact
-        project.name = name
-
+        project.fca_score = fca_score
         db.session.commit()
 
-        return jsonify({"success": True, "evaluation": evaluation_result}), 200
+        return jsonify({"success": True, "fca_score": fca_score}), 200
 
     except Exception as e:
         return jsonify({"error": str(e)}), 500

--- a/src/models/models.py
+++ b/src/models/models.py
@@ -28,6 +28,7 @@ class Project(db.Model):
     x_value = db.Column(db.Numeric, nullable=False)
     y_value = db.Column(db.Numeric, nullable=False)
     impact = db.Column(db.Numeric, nullable=False)
+    fca_score = db.Column(db.Numeric, nullable=True)
     name = db.Column(db.String(255), nullable=False)
     thread_id = db.Column(db.String, nullable=False, unique=True)
     timestamp = db.Column(
@@ -42,6 +43,7 @@ class Project(db.Model):
             "x_value": self.x_value,
             "y_value": self.y_value,
             "impact": self.impact,
+            "fca_score": self.fca_score,
             "name": self.name,
             "thread_id": self.thread_id,
             "timestamp": self.timestamp.isoformat() if self.timestamp else None,

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -66,7 +66,7 @@
 
 
   <div id="evaluation-result" style="display: none; margin-top: 20px">
-    <h2>Project Evaluation</h2>
+    <h2>FCA Score</h2>
     <pre id="evaluation-output" style="background: #f8f8f8; padding: 10px"></pre>
   </div>
 
@@ -199,7 +199,7 @@
             document.getElementById("evaluation-result").style.display =
               "block";
             document.getElementById("evaluation-output").textContent =
-              JSON.stringify(data.evaluation, null, 2);
+              data.fca_score;
           }
         })
         .catch((error) => console.error("Error:", error));

--- a/tests/pytest/test_project.py
+++ b/tests/pytest/test_project.py
@@ -55,7 +55,7 @@ def test_evaluate_project(client):
     assert response.status_code == 200
 
     response_data = response.get_json()
-    assert "evaluation" in response_data
+    assert "fca_score" in response_data
 
 
 def test_update_project(client):


### PR DESCRIPTION
## Summary
- add `fca_score` column to `Project`
- evaluate projects using BMC validator and store `fca_score`
- show the FCA score on the homepage
- update tests for new API response

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685cfe47fcc883298a3c8a5cb9176bd4