### PR TITLE
Fix textarea resizing

### DIFF
--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -360,8 +360,8 @@ header.shrink .tab-link {
   width: 100%;
   resize: none;
   min-height: 40px;
-  max-height: 200px;
-  overflow-y: hidden;
+  max-height: 300px;
+  overflow-y: auto;
   transition: border-color 0.3s ease, box-shadow 0.3s ease;
   box-sizing: border-box;
 }
@@ -517,8 +517,8 @@ header.shrink .tab-link {
   padding: 8px 12px;
   resize: none;
   min-height: 40px;
-  max-height: 200px;
-  overflow-y: hidden;
+  max-height: 300px;
+  overflow-y: auto;
   transition: border-color 0.3s ease, box-shadow 0.3s ease;
   box-sizing: border-box;
 }

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -268,11 +268,14 @@
     });
     // Tee textarea käyttäytyy kuin chatissä (automaattinen korkeus)
     const textarea = document.getElementById("user-input");
+    const MAX_HEIGHT = 300; // maximum height for the textarea
 
     textarea.addEventListener("input", () => {
       textarea.style.height = "auto";
-      textarea.style.height = textarea.scrollHeight + "px";
-      localStorage.setItem("userInput", textarea.value); // Tallenna localStorageen
+      const newHeight = Math.min(textarea.scrollHeight, MAX_HEIGHT);
+      textarea.style.height = `${newHeight}px`;
+      textarea.style.overflowY = textarea.scrollHeight > MAX_HEIGHT ? "auto" : "hidden";
+      localStorage.setItem("userInput", textarea.value);
     });
 
     // Lähetä viesti Enterillä, rivinvaihto Shift+Enterillä


### PR DESCRIPTION
## Summary
- allow longer textarea content by increasing max height
- make overflow auto for scrolling past the limit
- cap textarea height in JS and add scrollbar logic

## Testing
- `./run_tests.sh` *(fails: OPENAI_API_KEY not set)*

------
https://chatgpt.com/codex/tasks/task_e_685e7860b07c8329970380f10191da3e